### PR TITLE
REFACTOR : modify jwt payLoad

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -23,7 +23,7 @@ const signin = async (email, password) =>{
         throw new CreateError(400,'Invalid Password')
     }
     
-    const payLoad    = {'id' : userData[0].id, 'role' : userData[0].role}
+    const payLoad    = {'id' : userData[0].id}
     const SCERET_KEY = process.env.SCERET_KEY
     const token      = jwt.sign(payLoad, SCERET_KEY)
 


### PR DESCRIPTION
- 토큰 payLoad에 userRole 제거


- 암호화되지 않은 payLoad에 유저의 권한을 담아 인증/인가 하는 방식은 위험성이 있다 판단하여 userId만 담았습니다.